### PR TITLE
feat: Add and configure Angular Material

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,6 +28,7 @@
               }
             ],
             "styles": [
+              "node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.scss"
             ]
           },
@@ -83,6 +84,7 @@
               }
             ],
             "styles": [
+              "node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
               "src/styles.scss"
             ]
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "name": "app-generator",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/cdk": "^20.1.6",
         "@angular/common": "^20.1.0",
         "@angular/compiler": "^20.1.0",
         "@angular/core": "^20.1.0",
         "@angular/forms": "^20.1.0",
+        "@angular/material": "^20.1.6",
         "@angular/platform-browser": "^20.1.0",
         "@angular/router": "^20.1.0",
         "rxjs": "~7.8.0",
@@ -401,6 +403,45 @@
         }
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.1.6.tgz",
+      "integrity": "sha512-GKxCS/GOAOQCNTnrvYia9wR4Z9rRWjzNRE0989LXwWLYcmiG7+ku30PolGV7zhmlgUu/qx8P6BbxZgUvK34X/A==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/cdk/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@angular/cdk/node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "20.1.6",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.1.6.tgz",
@@ -586,6 +627,23 @@
         "@angular/common": "20.1.7",
         "@angular/core": "20.1.7",
         "@angular/platform-browser": "20.1.7",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "20.1.6",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-20.1.6.tgz",
+      "integrity": "sha512-k2rjN6ABd5ahE4LWAJ5rv7Z3WAO6tgmjOrFZG7ED0xavhcGWyHroALFqdmlIkb2QFAAF186ifLIH+xgln9edqw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "20.1.6",
+        "@angular/common": "^20.0.0 || ^21.0.0",
+        "@angular/core": "^20.0.0 || ^21.0.0",
+        "@angular/forms": "^20.0.0 || ^21.0.0",
+        "@angular/platform-browser": "^20.0.0 || ^21.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
   },
   "private": true,
   "dependencies": {
+    "@angular/cdk": "^20.1.6",
     "@angular/common": "^20.1.0",
     "@angular/compiler": "^20.1.0",
     "@angular/core": "^20.1.0",
     "@angular/forms": "^20.1.0",
+    "@angular/material": "^20.1.6",
     "@angular/platform-browser": "^20.1.0",
     "@angular/router": "^20.1.0",
     "rxjs": "~7.8.0",

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.html
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.html
@@ -1,1 +1,8 @@
-<p>confirm-dialog works!</p>
+<h1 mat-dialog-title>{{ data.title }}</h1>
+<div mat-dialog-content>
+  <p>{{ data.message }}</p>
+</div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onDismiss()">Cancel</button>
+  <button mat-raised-button color="primary" (click)="onConfirm()" cdkFocusInitial>Confirm</button>
+</div>

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.ts
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.ts
@@ -1,11 +1,29 @@
-import { Component } from '@angular/core';
+import { Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
 
 @Component({
   selector: 'app-confirm-dialog',
-  imports: [],
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule],
   templateUrl: './confirm-dialog.html',
-  styleUrl: './confirm-dialog.scss'
+  styleUrl: './confirm-dialog.scss',
 })
 export class ConfirmDialog {
+  constructor(
+    public dialogRef: MatDialogRef<ConfirmDialog>,
+    @Inject(MAT_DIALOG_DATA) public data: { title: string; message: string }
+  ) {}
 
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  onDismiss(): void {
+    this.dialogRef.close(false);
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,1 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
+html, body { height: 100%; }
+body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }


### PR DESCRIPTION
Installs Angular Material and CDK and configures a global theme.

- Adds `@angular/material` and `@angular/cdk` to dependencies.
- Modifies `angular.json` to include a pre-built indigo-pink theme, resolving build issues with Sass `@use`.
- Adds global styles for body, html, and font-family in `styles.scss`.
- Refactors the `confirm-dialog` component to use `MatDialog` and `MatButton` as a demonstration of the new setup.